### PR TITLE
Remove remaining r-specific node references

### DIFF
--- a/lua/nvim-slimetree/get_nodes.lua
+++ b/lua/nvim-slimetree/get_nodes.lua
@@ -2,14 +2,25 @@ M = {}
 
 M.get_nodes = function()
   local out = {}
-  -- if filetype in set r, rmd, qmd
-  if vim.bo.filetype == "r" or vim.bo.filetype == "rmd" or vim.bo.filetype == "qmd" then
-    out.acceptable = require("nodes.R.acceptable")
-    out.skip = require("nodes.R.skip")
-    out.root = require("nodes.R.root")
-    out.sub_roots = require("nodes.R.sub_root")
-    out.bad_parents = require("nodes.R.bad_parents")
+
+  -- determine the language directory for node definitions
+  local ft = vim.bo.filetype
+  local lang_map = { rmd = "R", qmd = "R" }
+  local lang_dir = lang_map[ft] or ft
+
+  local ok, nodes = pcall(require, string.format("nodes.%s.acceptable", lang_dir))
+  if ok then
+    out.acceptable = nodes
+    ok, nodes = pcall(require, string.format("nodes.%s.skip", lang_dir))
+    out.skip = ok and nodes or {}
+    ok, nodes = pcall(require, string.format("nodes.%s.root", lang_dir))
+    out.root = ok and nodes or {}
+    ok, nodes = pcall(require, string.format("nodes.%s.sub_root", lang_dir))
+    out.sub_roots = ok and nodes or {}
+    ok, nodes = pcall(require, string.format("nodes.%s.bad_parents", lang_dir))
+    out.bad_parents = ok and nodes or {}
   end
+
   -- vim.notify(vim.inspect(out), "info", {title = "Nodes"})
   return out
 end

--- a/lua/nvim-slimetree/slimetree.lua
+++ b/lua/nvim-slimetree/slimetree.lua
@@ -133,20 +133,21 @@ local function get_node_under_cursor(bufnr, row, node_types)
 		end
 	end
 
-	if widest_node then
-		local current_node = widest_node
-		local parent = current_node:parent()
-		while parent and not is_root_node(parent:type(), node_types) and not parent:type() ~= "chunk" do
-			local parent_start_row, _, _, _ = parent:range()
-			if parent_start_row == row then
-				current_node = parent
-				parent = current_node:parent()
-			else
-				break
-			end
-		end
-		return current_node
-	end
+        if widest_node then
+                local current_node = widest_node
+                local parent = current_node:parent()
+                local boundary_nodes = utils.append(node_types.root, node_types.sub_roots)
+                while parent and not utils.in_set(parent:type(), boundary_nodes) do
+                        local parent_start_row, _, _, _ = parent:range()
+                        if parent_start_row == row then
+                                current_node = parent
+                                parent = current_node:parent()
+                        else
+                                break
+                        end
+                end
+                return current_node
+        end
 	-- Return the widest node if no suitable parent is found
 	return widest_node
 end


### PR DESCRIPTION
## Summary
- support loading node tables for any language
- stop hard-coded check for `chunk` node when traversing

## Testing
- `luacheck .` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6857f7fa0b08832fa6da87c5ada3cb6b