### PR TITLE
Fix tmux pane creation race

### DIFF
--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -1,8 +1,8 @@
 local M = {}
 
-local function exec_cmd(cmd)
+local function exec_cmd(cmd, ignore_errors)
   local out = vim.fn.system(cmd)
-  if vim.v.shell_error ~= 0 then
+  if vim.v.shell_error ~= 0 and not ignore_errors then
     vim.notify(string.format("Failed to execute command: %s\nError:%s", cmd, out), vim.log.levels.ERROR)
     return nil
   end
@@ -23,7 +23,7 @@ local function start_goo_impl(commands, window_name)
     return false
   end
 
-  exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name))
+  exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name), true)
   exec_cmd(string.format("tmux new-window -d -n %s -t %s:", window_name, session))
   for _ = 1, 3 do
     exec_cmd(string.format("tmux split-window -h -t %s:%s", session, window_name))
@@ -74,7 +74,7 @@ function M.end_goo(window_name)
 
   local session = get_session()
   if session then
-    exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name))
+    exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name), true)
   end
 
   for i = 1, 4 do

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -165,10 +165,10 @@ function M.end_goo(window_name)
        local pane_ids = {}
        for i = 1, 4 do
                -- Prefer the scoped variable
-               local pane_id = vim.fn.getenv(string.format("%s_%d", window_name, i))
+               local pane_id = os.getenv(string.format("%s_%d", window_name, i))
                -- Fall back to the legacy variable name
                if not pane_id or pane_id == "" then
-                       pane_id = vim.fn.getenv(string.format("GOO_PANE_%d", i))
+                       pane_id = os.getenv(string.format("GOO_PANE_%d", i))
                end
                if pane_id and pane_id ~= "" then
                        table.insert(pane_ids, pane_id)
@@ -227,11 +227,11 @@ function M.summon_goo(n, window_name)
 		return
 	end
 
-	local pane_id = vim.fn.getenv(string.format("%s_%d", window_name, n))
-	if not pane_id or pane_id == "" then
-		vim.notify("Pane ID not found. Make sure to run :StartGoo first.", vim.log.levels.ERROR)
-		return
-	end
+       local pane_id = os.getenv(string.format("%s_%d", window_name, n))
+       if not pane_id or pane_id == "" then
+               vim.notify("Pane ID not found. Make sure to run :StartGoo first.", vim.log.levels.ERROR)
+               return
+       end
 
 	-- Get the current window name
 	local current_window = exec_cmd("tmux display-message -p '#{window_name}'")
@@ -250,8 +250,8 @@ function M.summon_goo(n, window_name)
 	-- Move all goo panes back to 'gooTabs' (except those already there)
 	local panes_moved_back = false
 	for i = 1, 4 do
-		local pid = vim.fn.getenv(string.format("%s_%d", window_name, i))
-		if pid and pid ~= "" then
+                local pid = os.getenv(string.format("%s_%d", window_name, i))
+                if pid and pid ~= "" then
 			-- Get the window name of the pane
 			local pane_window = get_pane_window(pid)
 			if pane_window and pane_window ~= window_name then

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -1,13 +1,12 @@
 local M = {}
 
 local function exec_cmd(cmd)
-	local result = vim.fn.system(cmd)
-	local exit_code = vim.v.shell_error
-	if exit_code ~= 0 then
-		vim.notify(string.format("Failed to execute command: %s\nError: %s", cmd, result), vim.log.levels.ERROR)
-		return nil
-	end
-	return result
+  local out = vim.fn.system(cmd)
+  if vim.v.shell_error ~= 0 then
+    vim.notify(string.format("Failed to execute command: %s\nError:%s", cmd, out), vim.log.levels.ERROR)
+    return nil
+  end
+  return out
 end
 
 -- Function to escape special characters in Lua patterns
@@ -15,191 +14,88 @@ local function escape_lua_pattern(s)
 	return (s:gsub("([%%%^%$%(%)%.%[%]%*%+%-%?])", "%%%1"))
 end
 
+local function get_session()
+  local out = exec_cmd("tmux display-message -p '#S'")
+  return out and out:gsub("%s+", "") or nil
+end
+
 -- Function to create the gooTabs window with 4 panes
 local function start_goo_impl(commands, window_name)
-        window_name = window_name or "gooTabs"
-        _G.goo_started = true
-        -- Retrieve the current session name
-        local session_name = exec_cmd("tmux display-message -p '#S'")
-        if session_name then
-                session_name = session_name:gsub("%s+", "")
-        else
-                vim.notify("Failed to retrieve tmux session name.", vim.log.levels.ERROR)
-                _G.goo_started = false
-                _G.goo_busy = false
-                return {}
-        end
+  window_name = window_name or "gooTabs"
 
-        -- escape spaces in session name if present so tmux can interpret it as a single  argument
-        session_name = session_name:gsub(" ", "\\ ")
-        -- Check if 'gooTabs' window exists
-        local list_windows_cmd = string.format("tmux list-windows -t %s -F '#{window_name}'", session_name)
-        local windows_output = exec_cmd(list_windows_cmd)
-        local window_exists = false
+  local session = get_session()
+  if not session then
+    vim.notify("Failed to retrieve tmux session name.", vim.log.levels.ERROR)
+    return false
+  end
 
-        if windows_output then
-                for window in windows_output:gmatch("[^\r\n]+") do
-                        if window == window_name then
-                                window_exists = true
-                                break
-                        end
-                end
-        end
+  exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name))
+  exec_cmd(string.format("tmux new-window -d -n %s -t %s:", window_name, session))
+  for _ = 1, 3 do
+    exec_cmd(string.format("tmux split-window -h -t %s:%s", session, window_name))
+  end
+  exec_cmd(string.format("tmux select-layout -t %s:%s even-horizontal", session, window_name))
 
-        if window_exists then
-                -- 'gooTabs' window exists, proceed to kill it
-                local kill_cmd = string.format("tmux kill-window -t %s:%s", session_name, window_name)
-                exec_cmd(kill_cmd)
-        end
+  local out = exec_cmd(string.format("tmux list-panes -t %s:%s -F '#{pane_id}'", session, window_name))
+  if not out then return false end
 
-        -- Build a single tmux command string to create panes quickly
-        local cmds = {
-                string.format("tmux new-window -d -n %s -t %s:", window_name, session_name),
-                string.format("tmux split-window -h -t %s:%s", session_name, window_name),
-                string.format("tmux split-window -h -t %s:%s", session_name, window_name),
-                string.format("tmux split-window -h -t %s:%s", session_name, window_name),
-                string.format("tmux select-layout -t %s:%s even-horizontal", session_name, window_name),
-                string.format("tmux list-panes -t %s:%s -F '#{pane_id}'", session_name, window_name),
-        }
+  local panes = {}
+  for pid in out:gmatch("[^\r\n]+") do
+    table.insert(panes, pid:gsub("%s+", ""))
+  end
+  if #panes ~= 4 then return false end
 
-        local combined_cmd = table.concat(cmds, " ; ")
-        local pane_list = exec_cmd(combined_cmd)
-        if not pane_list or pane_list == "" then
-                vim.notify("Failed to create new window", vim.log.levels.ERROR)
-                _G.goo_started = false
-                _G.goo_busy = false
-                return {}
-        end
+  for i, pid in ipairs(panes) do
+    vim.fn.setenv(string.format("%s_%d", window_name, i), pid)
+    vim.fn.setenv(string.format("GOO_PANE_%d", i), pid)
+  end
 
-        local pane_ids = {}
-        for pid in pane_list:gmatch("[^\r\n]+") do
-                local sanitized = pid:gsub("%s+", "")
-                table.insert(pane_ids, sanitized)
-        end
-
-        -- Ensure we have exactly 4 panes
-        if #pane_ids ~= 4 then
-                vim.notify(string.format("Expected 4 panes, but found %d panes.", #pane_ids), vim.log.levels.ERROR)
-                _G.goo_started = false
-                _G.goo_busy = false
-                return {}
-        end
-
-       -- Store pane IDs in environment variables
-       for i, pane_id in ipairs(pane_ids) do
-               -- New scoped variable name
-               vim.fn.setenv(string.format("%s_%d", window_name, i), pane_id)
-               -- Backwards-compatible variable used by earlier configs
-               vim.fn.setenv(string.format("GOO_PANE_%d", i), pane_id)
-       end
-
-       -- Send commands to panes using a single tmux call for speed
-        local send_cmds = {}
-        for i, pane_id in ipairs(pane_ids) do
-                local cmd_to_run = nil
-                if commands then
-                        if type(commands) == "table" then
-                                cmd_to_run = commands[i] or ""
-                        else
-                                cmd_to_run = commands
-                        end
-                else
-                        cmd_to_run = ""
-                end
-
-                if cmd_to_run and cmd_to_run ~= "" then
-                        table.insert(send_cmds, string.format("tmux send-keys -t %s '%s' Enter", pane_id, cmd_to_run))
-                end
-        end
-        if #send_cmds > 0 then
-                exec_cmd(table.concat(send_cmds, " ; "))
-        end
-
-       -- vim.notify("gooTabs window with 4 vertical panes created successfully.", vim.log.levels.INFO)
-       _G.goo_busy = false
-       return pane_ids
+  if commands then
+    local send_cmds = {}
+    for i, pid in ipairs(panes) do
+      local cmd = type(commands) == "table" and commands[i] or commands
+      if cmd and cmd ~= "" then
+        table.insert(send_cmds, string.format("tmux send-keys -t %s %q Enter", pid, cmd))
+      end
+    end
+    if #send_cmds > 0 then exec_cmd(table.concat(send_cmds, " ; ")) end
+  end
+  return true
 end
 
 -- Public async wrapper so pane creation doesn't block UI
 function M.start_goo(commands, window_name)
-        if _G.goo_busy then
-                -- Avoid starting a second setup while one is already running
-                return
-        end
-        _G.goo_busy = true
-        vim.schedule(function()
-                start_goo_impl(commands, window_name)
-        end)
+  if _G.goo_busy then return end
+  _G.goo_busy = true
+  vim.schedule(function()
+    local ok = start_goo_impl(commands, window_name)
+    _G.goo_started = ok
+    _G.goo_busy = false
+  end)
 end
 
--- Function to check if a pane exists
-local function pane_exists(pane_id)
-	local panes_output = exec_cmd("tmux list-panes -a -F '#{pane_id}'")
-	if not panes_output then
-		return false
-	end
-	-- Escape special characters in pane_id
-	local escaped_pane_id = escape_lua_pattern(pane_id)
-	if panes_output:find(escaped_pane_id) then
-		return true
-	else
-		return false
-	end
-end
-
--- Function to end goo session by killing panes and the gooTabs window
+-- End goo session by killing the window and clearing variables
 function M.end_goo(window_name)
-        if _G.goo_busy then
-                vim.defer_fn(function() M.end_goo(window_name) end, 100)
-                return
-        end
-        _G.goo_busy = true
-        window_name = window_name or "gooTabs"
+  if _G.goo_busy then
+    vim.defer_fn(function() M.end_goo(window_name) end, 100)
+    return
+  end
+  _G.goo_busy = true
+  window_name = window_name or "gooTabs"
 
-       -- Retrieve pane IDs from environment variables
-       local pane_ids = {}
-       for i = 1, 4 do
-               -- Prefer the scoped variable
-               local pane_id = os.getenv(string.format("%s_%d", window_name, i))
-               -- Fall back to the legacy variable name
-               if not pane_id or pane_id == "" then
-                       pane_id = os.getenv(string.format("GOO_PANE_%d", i))
-               end
-               if pane_id and pane_id ~= "" then
-                       table.insert(pane_ids, pane_id)
-               end
-       end
+  local session = get_session()
+  if session then
+    exec_cmd(string.format("tmux kill-window -t %s:%s 2>/dev/null", session, window_name))
+  end
 
-       -- Kill each pane if it exists
-        for _, pane_id in ipairs(pane_ids) do
-                if pane_exists(pane_id) then
-                        local kill_cmd = string.format("tmux kill-pane -t %s", pane_id)
-                        local kill_output = exec_cmd(kill_cmd)
-                        if not kill_output then
-                                vim.notify("Failed to kill pane " .. pane_id, vim.log.levels.ERROR)
-                        end
-                end
-        end
+  for i = 1, 4 do
+    vim.fn.setenv(string.format("%s_%d", window_name, i), nil)
+    vim.fn.setenv(string.format("GOO_PANE_%d", i), nil)
+  end
 
-       -- Finally kill the gooTabs window itself if it still exists
-       local session_name = exec_cmd("tmux display-message -p '#S'")
-       if session_name then
-               session_name = session_name:gsub("%s+", "")
-               local kill_window_cmd = string.format("tmux kill-window -t %s:%s", session_name, window_name)
-               exec_cmd(kill_window_cmd)
-       end
-
-       -- Unset the environment variables
-       for i = 1, 4 do
-               vim.fn.setenv(string.format("%s_%d", window_name, i), nil)
-               -- Also unset legacy variable for compatibility
-               vim.fn.setenv(string.format("GOO_PANE_%d", i), nil)
-       end
-
-       _G.goo_started = false
-       _G.goo_busy = false
-
-       vim.notify("All goo panes and the '" .. window_name .. "' window have been closed.", vim.log.levels.INFO)
+  _G.goo_started = false
+  _G.goo_busy = false
+  vim.notify("All goo panes and the '" .. window_name .. "' window have been closed.", vim.log.levels.INFO)
 end
 
 -- Function to summon a specific goo pane into the current window
@@ -216,84 +112,57 @@ end
 -- Function to summon a specific goo pane into the current window
 function M.summon_goo(n, window_name)
   if _G.goo_busy then
-    vim.defer_fn(function()
-      M.summon_goo(n, window_name)
-    end, 50)
+    vim.defer_fn(function() M.summon_goo(n, window_name) end, 50)
     return
   end
   window_name = window_name or "gooTabs"
-	-- Ensure 'n' is between 1 and 4
-	if type(n) ~= "number" or n < 1 or n > 4 then
-		vim.notify("Please provide a pane number between 1 and 4.", vim.log.levels.ERROR)
-		return
-	end
+  if type(n) ~= "number" or n < 1 or n > 4 then
+    vim.notify("Please provide a pane number between 1 and 4.", vim.log.levels.ERROR)
+    return
+  end
 
   local pane_id = os.getenv(string.format("%s_%d", window_name, n))
+    or os.getenv(string.format("GOO_PANE_%d", n))
   if not pane_id or pane_id == "" then
     if _G.goo_busy or _G.goo_started then
-      vim.defer_fn(function()
-        M.summon_goo(n, window_name)
-      end, 50)
+      vim.defer_fn(function() M.summon_goo(n, window_name) end, 50)
     else
       vim.notify("Pane ID not found. Make sure to run :StartGoo first.", vim.log.levels.ERROR)
     end
     return
   end
 
-	-- Get the current window name
-	local current_window = exec_cmd("tmux display-message -p '#{window_name}'")
-	if not current_window then
-		vim.notify("Failed to retrieve current window name.", vim.log.levels.ERROR)
-		return
-	end
-	current_window = current_window:gsub("%s+", "") -- Trim whitespace
+  local current_window = exec_cmd("tmux display-message -p '#{window_name}'")
+  if not current_window then
+    vim.notify("Failed to retrieve current window name.", vim.log.levels.ERROR)
+    return
+  end
+  current_window = current_window:gsub("%s+", "")
+  if current_window == window_name then
+    vim.notify("Cannot summon panes within the 'gooTabs' window.", vim.log.levels.WARN)
+    return
+  end
 
-	-- Prevent moving panes within the gooTabs window
-	if current_window == window_name then
-		vim.notify("Cannot summon panes within the 'gooTabs' window.", vim.log.levels.WARN)
-		return
-	end
+  for i = 1, 4 do
+    local pid = os.getenv(string.format("%s_%d", window_name, i))
+      or os.getenv(string.format("GOO_PANE_%d", i))
+    if pid and pid ~= "" then
+      local pane_window = get_pane_window(pid)
+      if pane_window and pane_window ~= window_name then
+        exec_cmd(string.format("tmux move-pane -d -s %s -t %s", pid, window_name))
+      end
+    end
+  end
+  exec_cmd(string.format("tmux select-layout -t %s even-horizontal", window_name))
 
-	-- Move all goo panes back to 'gooTabs' (except those already there)
-	local panes_moved_back = false
-	for i = 1, 4 do
-                local pid = os.getenv(string.format("%s_%d", window_name, i))
-                if pid and pid ~= "" then
-			-- Get the window name of the pane
-			local pane_window = get_pane_window(pid)
-			if pane_window and pane_window ~= window_name then
-				-- Move the pane back to 'gooTabs' without changing focus
-				local move_cmd = string.format("tmux move-pane -d -s %s -t " .. window_name .. "", pid)
-				local move_output = exec_cmd(move_cmd)
-				if move_output == nil then
-					vim.notify(string.format("Failed to move pane %s back to " .. window_name .. "'.", pid), vim.log.levels.ERROR)
-				else
-					-- vim.notify(string.format("Moved pane %s back to 'gooTabs'.", pid), vim.log.levels.INFO)
-					panes_moved_back = true
-				end
-			end
-		end
-	end
+  local pane_window = get_pane_window(pane_id)
+  if pane_window == current_window then
+    vim.notify(string.format("Pane %d is already in the current window.", n), vim.log.levels.INFO)
+    return
+  end
 
-	-- Reset the layout in 'gooTabs' if any panes were moved back
-	if panes_moved_back then
-		local layout_cmd = "tmux select-layout -t " .. window_name .. " even-horizontal"
-		exec_cmd(layout_cmd)
-		-- vim.notify("Reset 'gooTabs' layout to even-horizontal.", vim.log.levels.INFO)
-	end
-
-	-- Now, check if the desired pane is already in the current window
-	local pane_window = get_pane_window(pane_id)
-	if pane_window == current_window then
-		vim.notify(string.format("Pane %d is already in the current window.", n), vim.log.levels.INFO)
-		return
-	end
-
-	-- Bring the specified pane into the current window to the right without changing focus
-	local summon_cmd = string.format("tmux join-pane -h -d -s %s -t %s -l 33%%", pane_id, current_window)
-	os.execute(summon_cmd)
-	_G.goo_started = true
-	-- vim.notify(string.format("Summoned pane %d (%s) to window '%s' to the right.", n, pane_id, current_window), vim.log.levels.INFO)
+  exec_cmd(string.format("tmux join-pane -h -d -s %s -t %s -l 33%%", pane_id, current_window))
+  _G.goo_started = true
 end
 
 return M

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -73,7 +73,8 @@ local function start_goo_impl(commands, window_name)
 
         local pane_ids = {}
         for pid in pane_list:gmatch("[^\r\n]+") do
-                table.insert(pane_ids, pid:gsub("%s+", ""))
+                local sanitized = pid:gsub("%s+", "")
+                table.insert(pane_ids, sanitized)
         end
 
         -- Ensure we have exactly 4 panes

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -8,12 +8,6 @@ local function exec_cmd(cmd)
   end
   return out
 end
-
--- Function to escape special characters in Lua patterns
-local function escape_lua_pattern(s)
-	return (s:gsub("([%%%^%$%(%)%.%[%]%*%+%-%?])", "%%%1"))
-end
-
 local function get_session()
   local out = exec_cmd("tmux display-message -p '#S'")
   return out and out:gsub("%s+", "") or nil
@@ -41,7 +35,7 @@ local function start_goo_impl(commands, window_name)
 
   local panes = {}
   for pid in out:gmatch("[^\r\n]+") do
-    table.insert(panes, pid:gsub("%s+", ""))
+    panes[#panes + 1] = pid:gsub("%s+", "")
   end
   if #panes ~= 4 then return false end
 

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -113,8 +113,9 @@ function M.start_goo(commands, window_name)
 		end
 	end
 
-	-- vim.notify("gooTabs window with 4 vertical panes created successfully.", vim.log.levels.INFO)
-	return pane_ids
+        _G.goo_started = true
+        -- vim.notify("gooTabs window with 4 vertical panes created successfully.", vim.log.levels.INFO)
+        return pane_ids
 end
 
 -- Function to check if a pane exists
@@ -168,7 +169,9 @@ function M.end_goo(window_name)
                vim.fn.setenv(string.format("GOO_PANE_%d", i), nil)
        end
 
-	vim.notify("All goo panes and the '" .. window_name .. "' window have been closed.", vim.log.levels.INFO)
+       _G.goo_started = false
+
+       vim.notify("All goo panes and the '" .. window_name .. "' window have been closed.", vim.log.levels.INFO)
 end
 
 -- Function to summon a specific goo pane into the current window

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -17,10 +17,6 @@ end
 
 -- Function to create the gooTabs window with 4 panes
 local function start_goo_impl(commands, window_name)
-        if _G.goo_busy then
-                return
-        end
-        _G.goo_busy = true
         window_name = window_name or "gooTabs"
         _G.goo_started = true
         -- Retrieve the current session name
@@ -132,6 +128,11 @@ end
 
 -- Public async wrapper so pane creation doesn't block UI
 function M.start_goo(commands, window_name)
+        if _G.goo_busy then
+                -- Avoid starting a second setup while one is already running
+                return
+        end
+        _G.goo_busy = true
         vim.schedule(function()
                 start_goo_impl(commands, window_name)
         end)

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -70,11 +70,6 @@ end
 
 -- End goo session by killing the window and clearing variables
 function M.end_goo(window_name)
-  if _G.goo_busy then
-    vim.defer_fn(function() M.end_goo(window_name) end, 100)
-    return
-  end
-  _G.goo_busy = true
   window_name = window_name or "gooTabs"
 
   local session = get_session()

--- a/lua/nvim-slimetree/gootabs.lua
+++ b/lua/nvim-slimetree/gootabs.lua
@@ -57,21 +57,27 @@ function M.start_goo(commands, window_name)
 		return {}
 	end
 
-        -- Split the initial pane vertically 3 times to create 4 vertical panes
-        local initial_pane = string.format("%s:%s.0", session_name, window_name)
+       -- Split the initial pane vertically 3 times to create 4 vertical panes
+       local initial_target = string.format("%s:%s.0", session_name, window_name)
+       local init_id_output = exec_cmd(string.format("tmux display-message -p -t %s '#{pane_id}'", initial_target))
+       if not init_id_output or init_id_output == "" then
+               vim.notify("Failed to retrieve initial pane id", vim.log.levels.ERROR)
+               return {}
+       end
+       local initial_pane_id = init_id_output:gsub("%s+", "")
 
-        local pane_ids = { initial_pane }
+       local pane_ids = { initial_pane_id }
 
-        for _ = 1, 3 do
-                local split_cmd = string.format("tmux split-window -h -P -F '#{pane_id}' -t %s", initial_pane)
-                local split_output = exec_cmd(split_cmd)
-                if not split_output then
-                        vim.notify("Failed to split pane with command: " .. split_cmd, vim.log.levels.ERROR)
-                        return {}
-                end
-                local new_pane = split_output:gsub("%s+", "")
-                table.insert(pane_ids, new_pane)
-        end
+       for _ = 1, 3 do
+               local split_cmd = string.format("tmux split-window -h -P -F '#{pane_id}' -t %s", initial_pane_id)
+               local split_output = exec_cmd(split_cmd)
+               if not split_output then
+                       vim.notify("Failed to split pane with command: " .. split_cmd, vim.log.levels.ERROR)
+                       return {}
+               end
+               local new_pane = split_output:gsub("%s+", "")
+               table.insert(pane_ids, new_pane)
+       end
 
         -- Reset layout to even-horizontal
         local layout_cmd = string.format("tmux select-layout -t %s:%s even-horizontal", session_name, window_name)

--- a/lua/nvim-slimetree/init.lua
+++ b/lua/nvim-slimetree/init.lua
@@ -1,4 +1,5 @@
 _G.goo_started = false
+_G.goo_busy = false
 _G.use_goo = true
 local M = {}
 M.gootabs = require("nvim-slimetree.gootabs")


### PR DESCRIPTION
## Summary
- remove the sleep-based race workaround for creating tmux panes
- capture pane ids directly from `tmux split-window`
- keep pane count check and set layout

## Testing
- `luacheck .` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a087cc28832f83a63b8df48495d5