### PR TITLE
feat: add python node support

### DIFF
--- a/lua/nodes/python/acceptable.lua
+++ b/lua/nodes/python/acceptable.lua
@@ -1,0 +1,23 @@
+return {
+  ["expression_statement"] = true,
+  ["assignment"] = true,
+  ["augmented_assignment"] = true,
+  ["return_statement"] = true,
+  ["import_statement"] = true,
+  ["for_statement"] = true,
+  ["while_statement"] = true,
+  ["if_statement"] = true,
+  ["function_definition"] = true,
+  ["class_definition"] = true,
+  ["call"] = true,
+  ["list"] = true,
+  ["dictionary"] = true,
+  ["tuple"] = true,
+  ["try_statement"] = true,
+  ["with_statement"] = true,
+  ["raise_statement"] = true,
+  ["pass_statement"] = true,
+  ["break_statement"] = true,
+  ["continue_statement"] = true,
+}
+

--- a/lua/nodes/python/bad_parents.lua
+++ b/lua/nodes/python/bad_parents.lua
@@ -1,0 +1,7 @@
+-- bad_parents.lua
+-- nodes with these parents will always be rejected
+return {
+  ["argument_list"] = true,
+  ["binary_operator"] = true,
+}
+

--- a/lua/nodes/python/root.lua
+++ b/lua/nodes/python/root.lua
@@ -1,0 +1,5 @@
+-- root.lua
+return {
+  ["module"] = true,
+}
+

--- a/lua/nodes/python/skip.lua
+++ b/lua/nodes/python/skip.lua
@@ -1,0 +1,4 @@
+return {
+  ["comment"] = true,
+}
+

--- a/lua/nodes/python/sub_root.lua
+++ b/lua/nodes/python/sub_root.lua
@@ -1,0 +1,5 @@
+-- sub_root.lua
+return {
+  ["block"] = true,
+}
+

--- a/lua/nvim-slimetree/get_nodes.lua
+++ b/lua/nvim-slimetree/get_nodes.lua
@@ -9,7 +9,7 @@ M.get_nodes = function()
     out.root = require("nodes.R.root")
     out.sub_roots = require("nodes.R.sub_root")
     out.bad_parents = require("nodes.R.bad_parents")
-  elseif vim.bo.filetype == "python" or vim.bo.filetype == "py" then
+  elseif vim.bo.filetype == "python" then
     out.acceptable = require("nodes.python.acceptable")
     out.skip = require("nodes.python.skip")
     out.root = require("nodes.python.root")

--- a/lua/nvim-slimetree/get_nodes.lua
+++ b/lua/nvim-slimetree/get_nodes.lua
@@ -9,6 +9,12 @@ M.get_nodes = function()
     out.root = require("nodes.R.root")
     out.sub_roots = require("nodes.R.sub_root")
     out.bad_parents = require("nodes.R.bad_parents")
+  elseif vim.bo.filetype == "python" or vim.bo.filetype == "py" then
+    out.acceptable = require("nodes.python.acceptable")
+    out.skip = require("nodes.python.skip")
+    out.root = require("nodes.python.root")
+    out.sub_roots = require("nodes.python.sub_root")
+    out.bad_parents = require("nodes.python.bad_parents")
   end
   -- vim.notify(vim.inspect(out), "info", {title = "Nodes"})
   return out


### PR DESCRIPTION
## Summary
- add treesitter node tables for Python
- initialize Python nodes in `get_nodes`

## Testing
- `luacheck lua/nvim-slimetree/get_nodes.lua lua/nodes/python/acceptable.lua lua/nodes/python/bad_parents.lua lua/nodes/python/root.lua lua/nodes/python/skip.lua lua/nodes/python/sub_root.lua`


------
https://chatgpt.com/codex/tasks/task_e_68956635f40c832f97e787942590f2c0