### PR TITLE
[codex] add native terminal transport backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This document is the contributor and implementation spec for `nvim-slimetree`.
 
 The plugin has two independent domains:
 
-1. `slimetree`: choose executable chunk under/after cursor and send to configured transport (`tmux_native` or `vim-slime` fallback).
+1. `slimetree`: choose executable chunk under/after cursor and send to configured transport (`tmux_native`, managed `terminal`, or `vim-slime` fallback).
 2. `gootabs`: optional tmux pane/window orchestration for multi-REPL workflows.
 
 `slimetree` must work even when `gootabs` is disabled.
@@ -39,6 +39,7 @@ lua/
       cursor.lua
       transport/
         init.lua
+        terminal.lua
         tmux_native.lua
         slime.lua
   nodes/
@@ -73,11 +74,13 @@ Defines defaults and configuration normalization.
 Config keys:
 
 - `repl.require_gootabs` (default `false`)
-- `transport.backend` (`auto|tmux_native|slime`, default `auto`)
+- `transport.backend` (`auto|tmux_native|terminal|slime`, default `auto`)
 - `transport.async` (default `true`)
 - `transport.mode` (`control|exec`, default `control`)
 - `transport.max_queue` (default `256`)
 - `transport.fallback_to_slime` (default `true`)
+- `transport.terminal.append_newline` (default `true`)
+- `transport.terminal.bracketed_paste` (`auto|true|false`, default `auto`)
 - `transport.tmux.buffer_name` (default `"slimetree_send"`)
 - `transport.tmux.cancel_copy_mode` (default `true`)
 - `transport.tmux.bracketed_paste` (`auto|true|false`, default `auto`)
@@ -161,6 +164,14 @@ Compatibility shims:
 - `SlimeCurrentLine()` -> `send_line`
 
 `send_current` must return structured status and never assume tmux unless configured.
+
+Managed Neovim terminal targets are configured via:
+
+- `b:slimetree_terminal_config`
+- `g:slimetree_terminal_config`
+
+with `{ bufnr = <terminal_bufnr> }` or `{ jobid = <terminal_jobid> }`.
+When `slime_target` resolves to `neovim`, native terminal transport may also reuse `b:slime_config` / `g:slime_default_config`.
 
 ### `gootabs.lua`
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Built-in node specs are included for:
 - tmux/gootabs is **off** by default.
 - REPL send auto-selects transport:
   - native tmux async sender when tmux target config is present
+  - native Neovim terminal sender when a managed terminal target is present
   - `vim-slime` fallback otherwise.
 
 ## Installation
@@ -99,11 +100,15 @@ end)
 ```lua
 st.setup({
   transport = {
-    backend = "auto", -- auto|tmux_native|slime
+    backend = "auto", -- auto|tmux_native|terminal|slime
     async = true,
     mode = "control", -- currently handled by native sender implementation
     max_queue = 256,
     fallback_to_slime = true,
+    terminal = {
+      append_newline = true,
+      bracketed_paste = "auto", -- auto|true|false
+    },
     tmux = {
       buffer_name = "slimetree_send",
       cancel_copy_mode = true,
@@ -114,6 +119,28 @@ st.setup({
   },
 })
 ```
+
+## Managed Neovim terminal target
+
+`nvim-slimetree` can send directly to a managed Neovim terminal job without routing through `vim-slime`.
+
+Set a global or buffer-local target:
+
+```lua
+vim.g.slimetree_terminal_config = {
+  bufnr = term_bufnr, -- or jobid = terminal_jobid
+}
+
+require("nvim-slimetree").setup({
+  transport = {
+    backend = "auto",
+  },
+})
+```
+
+`auto` keeps native tmux first. Terminal send is only chosen when no tmux target is configured and a managed terminal target is available.
+
+For compatibility, the native terminal transport also reuses `vim-slime`'s Neovim target config when `slime_target` is `neovim`.
 
 ## Deprecated (still shimmed)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,66 @@
+# Terminal Transport Support
+
+## Goal
+
+Add a native Neovim terminal transport to `nvim-slimetree` so managed terminal sessions can receive chunk sends without going through `vim-slime`, while preserving the existing native tmux path and generic slime fallback.
+
+## Constraints
+
+- Keep tmux first-class.
+- Keep the existing public send API unchanged.
+- Do not add terminal lifecycle management to `nvim-slimetree`.
+- Do not regress current `vim-slime` fallback behavior.
+
+## Design
+
+### Backend selection
+
+- Extend `transport.backend` to accept `terminal`.
+- In `auto` mode, resolve backends in this order:
+  1. `tmux_native` when a tmux target is configured
+  2. `terminal` when a managed Neovim terminal target is configured
+  3. `slime` fallback otherwise
+
+This keeps tmux preferred whenever both target types are available.
+
+### Terminal target contract
+
+Add a repo-owned managed terminal target shape:
+
+```lua
+vim.g.slimetree_terminal_config = {
+  bufnr = 12, -- optional if jobid is provided
+  jobid = 34, -- optional if bufnr resolves to a terminal channel
+}
+```
+
+Supported scopes:
+
+- `b:slimetree_terminal_config`
+- `g:slimetree_terminal_config`
+
+For interoperability, the native terminal backend may also reuse:
+
+- `b:slime_config`
+- `g:slime_default_config`
+
+but only when `slime_target` resolves to `neovim`.
+
+### Send semantics
+
+- Terminal sends are synchronous and queue-free.
+- Accept either `jobid` or `bufnr`; derive the missing value when possible.
+- Validate that any supplied buffer is a terminal buffer.
+- Support optional bracketed paste and newline append behavior under `transport.terminal`.
+
+## Non-goals
+
+- No terminal window creation or management helpers.
+- No changes to `gootabs`.
+- No attempt to replace `vim-slime` for non-tmux, non-terminal targets.
+
+## Verification
+
+- Config normalization tests for the new backend and terminal defaults.
+- Backend resolution tests covering tmux preference and terminal fallback.
+- Focused transport tests for terminal target resolution and send behavior.

--- a/lua/nvim-slimetree/config.lua
+++ b/lua/nvim-slimetree/config.lua
@@ -24,6 +24,10 @@ local defaults = {
     mode = "control",
     max_queue = 256,
     fallback_to_slime = true,
+    terminal = {
+      append_newline = true,
+      bracketed_paste = "auto",
+    },
     tmux = {
       buffer_name = "slimetree_send",
       cancel_copy_mode = true,
@@ -74,6 +78,7 @@ function M.normalize(user_opts)
 
   local valid_backend = {
     auto = true,
+    terminal = true,
     tmux_native = true,
     slime = true,
   }
@@ -100,6 +105,20 @@ function M.normalize(user_opts)
   end
 
   cfg.transport.fallback_to_slime = cfg.transport.fallback_to_slime ~= false
+
+  if type(cfg.transport.terminal) ~= "table" then
+    cfg.transport.terminal = deepcopy(defaults.transport.terminal)
+  end
+
+  local terminal_bracketed = cfg.transport.terminal.bracketed_paste
+  if terminal_bracketed ~= "auto" and type(terminal_bracketed) ~= "boolean" then
+    cfg.transport.terminal.bracketed_paste = "auto"
+  end
+  cfg.transport.terminal.append_newline = cfg.transport.terminal.append_newline ~= false
+
+  if type(cfg.transport.tmux) ~= "table" then
+    cfg.transport.tmux = deepcopy(defaults.transport.tmux)
+  end
 
   local valid_enter_mode = {
     auto = true,

--- a/lua/nvim-slimetree/core/transport/init.lua
+++ b/lua/nvim-slimetree/core/transport/init.lua
@@ -1,8 +1,42 @@
 local slime = require("nvim-slimetree.core.transport.slime")
 local state = require("nvim-slimetree.state")
+local terminal = require("nvim-slimetree.core.transport.terminal")
 local tmux_native = require("nvim-slimetree.core.transport.tmux_native")
 
 local M = {}
+
+local function send_with_slime(text)
+  local out = slime.send(text, {
+    append_newline = true,
+  })
+  state.transport.backend = "slime"
+  state.transport.connected = out.ok
+  if out.ok then
+    state.transport.last_error = nil
+  else
+    state.transport.last_error = out.reason
+  end
+  return out
+end
+
+local function send_with_fallback(text, cfg, backend_name, result)
+  if result.ok or not cfg.transport.fallback_to_slime then
+    return result
+  end
+
+  local fallback = slime.send(text, { append_newline = true })
+  if fallback.ok then
+    state.transport.stats.fallback = (state.transport.stats.fallback or 0) + 1
+    state.transport.last_error = nil
+  end
+  fallback.fallback_from = backend_name
+  state.transport.backend = "slime"
+  state.transport.connected = fallback.ok
+  if not fallback.ok then
+    state.transport.last_error = fallback.reason
+  end
+  return fallback
+end
 
 function M.resolve_backend(cfg, bufnr)
   local transport_cfg = (cfg and cfg.transport) or state.config.transport
@@ -11,6 +45,9 @@ function M.resolve_backend(cfg, bufnr)
   if selected == "auto" then
     if tmux_native.can_send(bufnr) then
       return "tmux_native"
+    end
+    if terminal.can_send(bufnr) then
+      return "terminal"
     end
     return "slime"
   end
@@ -21,6 +58,14 @@ function M.resolve_backend(cfg, bufnr)
 
   if selected == "tmux_native" then
     return "tmux_native"
+  end
+
+  if selected == "terminal" and not terminal.can_send(bufnr) then
+    return "slime"
+  end
+
+  if selected == "terminal" then
+    return "terminal"
   end
 
   return "slime"
@@ -40,36 +85,28 @@ function M.send(text, opts)
       async = opts.async,
       transport_cfg = cfg.transport,
     })
-
-    if (not result.ok) and cfg.transport.fallback_to_slime then
-      local fallback = slime.send(text, { append_newline = true })
-      if fallback.ok then
-        state.transport.stats.fallback = (state.transport.stats.fallback or 0) + 1
-      end
-      fallback.fallback_from = "tmux_native"
-      state.transport.backend = "slime"
-      state.transport.connected = fallback.ok
-      return fallback
-    end
-
-    return result
+    return send_with_fallback(text, cfg, "tmux_native", result)
   end
 
-  local out = slime.send(text, {
-    append_newline = true,
-  })
-  state.transport.backend = "slime"
-  state.transport.connected = out.ok
-  if not out.ok then
-    state.transport.last_error = out.reason
+  if backend == "terminal" then
+    result = terminal.send(text, {
+      bufnr = bufnr,
+      transport_cfg = cfg.transport,
+    })
+    return send_with_fallback(text, cfg, "terminal", result)
   end
-  return out
+
+  return send_with_slime(text)
 end
 
 function M.status()
   local backend = M.resolve_backend(state.config, vim.api.nvim_get_current_buf())
   if backend == "tmux_native" then
     return tmux_native.status()
+  end
+
+  if backend == "terminal" then
+    return terminal.status()
   end
 
   return {
@@ -84,7 +121,19 @@ function M.status()
 end
 
 function M.restart()
-  return tmux_native.restart()
+  local backend = M.resolve_backend(state.config, vim.api.nvim_get_current_buf())
+  if backend == "tmux_native" then
+    return tmux_native.restart()
+  end
+  if backend == "terminal" then
+    return terminal.restart()
+  end
+  state.reset_transport()
+  return {
+    ok = true,
+    reason = "ok",
+    backend = "slime",
+  }
 end
 
 return M

--- a/lua/nvim-slimetree/core/transport/terminal.lua
+++ b/lua/nvim-slimetree/core/transport/terminal.lua
@@ -1,0 +1,259 @@
+local state = require("nvim-slimetree.state")
+
+local M = {}
+
+local function ensure_state()
+  state.transport = state.transport or {}
+  state.transport.stats = state.transport.stats or {}
+  state.transport.stats.enqueued = state.transport.stats.enqueued or 0
+  state.transport.stats.sent = state.transport.stats.sent or 0
+  state.transport.stats.failed = state.transport.stats.failed or 0
+  state.transport.stats.fallback = state.transport.stats.fallback or 0
+  if state.transport.running == nil then
+    state.transport.running = false
+  end
+  if state.transport.connected == nil then
+    state.transport.connected = false
+  end
+end
+
+local function bool_from_number(v)
+  if type(v) == "number" then
+    return v ~= 0
+  end
+  return not not v
+end
+
+local function resolve_slimetree_config(bufnr)
+  local local_cfg = nil
+  pcall(function()
+    local_cfg = vim.b[bufnr].slimetree_terminal_config
+  end)
+
+  if type(local_cfg) == "table" then
+    return local_cfg
+  end
+
+  if type(vim.g.slimetree_terminal_config) == "table" then
+    return vim.g.slimetree_terminal_config
+  end
+
+  return nil
+end
+
+local function resolve_slime_config(bufnr)
+  local local_cfg = nil
+  pcall(function()
+    local_cfg = vim.b[bufnr].slime_config
+  end)
+
+  if type(local_cfg) == "table" then
+    return local_cfg
+  end
+
+  if type(vim.g.slime_default_config) == "table" then
+    return vim.g.slime_default_config
+  end
+
+  return nil
+end
+
+local function resolve_slime_target(bufnr)
+  local local_target = nil
+  pcall(function()
+    local_target = vim.b[bufnr].slime_target
+  end)
+
+  if type(local_target) == "string" and local_target ~= "" then
+    return local_target
+  end
+
+  if type(vim.g.slime_target) == "string" and vim.g.slime_target ~= "" then
+    return vim.g.slime_target
+  end
+
+  return nil
+end
+
+local function resolve_bracketed_paste(bracketed_opt)
+  if type(bracketed_opt) == "boolean" then
+    return bracketed_opt
+  end
+
+  if bracketed_opt == "auto" then
+    return bool_from_number(vim.g.slime_bracketed_paste)
+  end
+
+  return false
+end
+
+local function resolve_target_config(bufnr)
+  local cfg = resolve_slimetree_config(bufnr)
+  if type(cfg) == "table" then
+    return cfg
+  end
+
+  if resolve_slime_target(bufnr) == "neovim" then
+    return resolve_slime_config(bufnr)
+  end
+
+  return nil
+end
+
+local function validate_terminal_buffer(bufnr)
+  if type(bufnr) ~= "number" or bufnr < 1 or not vim.api.nvim_buf_is_valid(bufnr) then
+    return nil, "terminal_buffer_invalid"
+  end
+
+  local ok, buftype = pcall(function()
+    return vim.bo[bufnr].buftype
+  end)
+  if not ok or buftype ~= "terminal" then
+    return nil, "terminal_buffer_invalid"
+  end
+
+  local ok_channel, channel = pcall(vim.fn.getbufvar, bufnr, "&channel")
+  local jobid = tonumber(channel)
+  if not ok_channel or not jobid or jobid <= 0 then
+    return nil, "terminal_job_missing"
+  end
+
+  return jobid
+end
+
+function M.resolve_target(bufnr)
+  local cfg = resolve_target_config(bufnr)
+  if type(cfg) ~= "table" then
+    return nil, "terminal_target_missing"
+  end
+
+  local target = {
+    bufnr = tonumber(cfg.bufnr),
+    jobid = tonumber(cfg.jobid),
+  }
+
+  if target.bufnr ~= nil then
+    local buf_jobid, err = validate_terminal_buffer(target.bufnr)
+    if not buf_jobid then
+      return nil, err
+    end
+
+    if target.jobid ~= nil and target.jobid ~= buf_jobid then
+      return nil, "terminal_job_mismatch"
+    end
+
+    target.jobid = buf_jobid
+  end
+
+  if target.jobid == nil or target.jobid <= 0 then
+    return nil, "terminal_job_missing"
+  end
+
+  return target
+end
+
+function M.can_send(bufnr)
+  local target = M.resolve_target(bufnr)
+  return target ~= nil
+end
+
+local function wrap_bracketed_paste(payload)
+  local has_newline = payload:sub(-1) == "\n"
+  if has_newline then
+    payload = payload:sub(1, -2)
+  end
+
+  payload = "\27[200~" .. payload .. "\27[201~"
+  if has_newline then
+    payload = payload .. "\n"
+  end
+
+  return payload
+end
+
+function M.send(text, opts)
+  ensure_state()
+
+  opts = opts or {}
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local transport_cfg = opts.transport_cfg or state.config.transport
+
+  local raw_text = tostring(text or "")
+  if raw_text == "" then
+    return { ok = false, reason = "empty_payload" }
+  end
+
+  local payload = raw_text
+  if transport_cfg.terminal.append_newline and payload:sub(-1) ~= "\n" then
+    payload = payload .. "\n"
+  end
+
+  if resolve_bracketed_paste(transport_cfg.terminal.bracketed_paste) then
+    payload = wrap_bracketed_paste(payload)
+  end
+
+  local target, target_err = M.resolve_target(bufnr)
+  if not target then
+    state.transport.connected = false
+    state.transport.last_error = target_err or "terminal_target_missing"
+    return {
+      ok = false,
+      reason = target_err or "terminal_target_missing",
+      backend = "terminal",
+    }
+  end
+
+  local ok, err = pcall(vim.api.nvim_chan_send, target.jobid, payload)
+  if not ok then
+    state.transport.connected = false
+    state.transport.backend = "terminal"
+    state.transport.last_error = tostring(err)
+    state.transport.stats.failed = state.transport.stats.failed + 1
+    return {
+      ok = false,
+      reason = "terminal_send_failed",
+      backend = "terminal",
+      error = tostring(err),
+    }
+  end
+
+  state.transport.connected = true
+  state.transport.backend = "terminal"
+  state.transport.last_error = nil
+  state.transport.stats.sent = state.transport.stats.sent + 1
+
+  return {
+    ok = true,
+    reason = "ok",
+    backend = "terminal",
+    enqueued = false,
+    queue_depth = 0,
+    bufnr = target.bufnr,
+    jobid = target.jobid,
+  }
+end
+
+function M.status()
+  ensure_state()
+
+  return {
+    backend = "terminal",
+    mode = state.config.transport.mode,
+    queue_depth = 0,
+    running = false,
+    connected = state.transport.connected,
+    last_error = state.transport.last_error,
+    stats = vim.deepcopy(state.transport.stats),
+  }
+end
+
+function M.restart()
+  state.reset_transport()
+  return {
+    ok = true,
+    reason = "ok",
+    backend = "terminal",
+  }
+end
+
+return M

--- a/tests/spec/config_spec.lua
+++ b/tests/spec/config_spec.lua
@@ -40,7 +40,19 @@ describe("config.normalize", function()
     assert.is_true(cfg.transport.async)
     assert.are.equal(256, cfg.transport.max_queue)
     assert.is_true(cfg.transport.fallback_to_slime)
+    assert.is_true(cfg.transport.terminal.append_newline)
+    assert.are.equal("auto", cfg.transport.terminal.bracketed_paste)
     assert.are.equal("slimetree_send", cfg.transport.tmux.buffer_name)
+  end)
+
+  it("accepts terminal as an explicit backend", function()
+    local cfg = config.normalize({
+      transport = {
+        backend = "terminal",
+      },
+    })
+
+    assert.are.equal("terminal", cfg.transport.backend)
   end)
 
   it("normalizes invalid transport fields to safe defaults", function()
@@ -49,6 +61,9 @@ describe("config.normalize", function()
         backend = "wat",
         mode = "bad",
         max_queue = -9,
+        terminal = {
+          bracketed_paste = "bad",
+        },
         tmux = {
           bracketed_paste = "bad",
           enter_mode = "bad",
@@ -60,6 +75,7 @@ describe("config.normalize", function()
     assert.are.equal("auto", cfg.transport.backend)
     assert.are.equal("control", cfg.transport.mode)
     assert.are.equal(1, cfg.transport.max_queue)
+    assert.are.equal("auto", cfg.transport.terminal.bracketed_paste)
     assert.are.equal("auto", cfg.transport.tmux.bracketed_paste)
     assert.are.equal("auto", cfg.transport.tmux.enter_mode)
     assert.are.equal("slimetree_send", cfg.transport.tmux.buffer_name)

--- a/tests/spec/transport_spec.lua
+++ b/tests/spec/transport_spec.lua
@@ -1,12 +1,15 @@
 local config = require("nvim-slimetree.config")
 local state = require("nvim-slimetree.state")
 local transport = require("nvim-slimetree.core.transport")
+local terminal = require("nvim-slimetree.core.transport.terminal")
 local tmux_native = require("nvim-slimetree.core.transport.tmux_native")
 
 describe("core.transport backend resolution", function()
   before_each(function()
     state.config = config.normalize()
     state.reset_transport()
+    vim.g.slimetree_terminal_config = nil
+    vim.g.slime_target = nil
     vim.g.slime_default_config = nil
   end)
 
@@ -25,10 +28,53 @@ describe("core.transport backend resolution", function()
     assert.are.equal("tmux_native", backend)
   end)
 
+  it("uses terminal in auto mode when a managed terminal target exists", function()
+    vim.g.slimetree_terminal_config = {
+      jobid = 17,
+    }
+
+    local backend = transport.resolve_backend(state.config, 0)
+    assert.are.equal("terminal", backend)
+  end)
+
+  it("prefers tmux_native over terminal in auto mode", function()
+    vim.g.slime_default_config = {
+      socket_name = "default",
+      target_pane = "%1",
+    }
+    vim.g.slimetree_terminal_config = {
+      jobid = 17,
+    }
+
+    local backend = transport.resolve_backend(state.config, 0)
+    assert.are.equal("tmux_native", backend)
+  end)
+
+  it("reuses slime neovim config as a terminal target", function()
+    vim.g.slime_target = "neovim"
+    vim.g.slime_default_config = {
+      jobid = 23,
+    }
+
+    local backend = transport.resolve_backend(state.config, 0)
+    assert.are.equal("terminal", backend)
+  end)
+
   it("falls back to slime when tmux_native is requested but target is missing", function()
     state.config = config.normalize({
       transport = {
         backend = "tmux_native",
+      },
+    })
+
+    local backend = transport.resolve_backend(state.config, 0)
+    assert.are.equal("slime", backend)
+  end)
+
+  it("falls back to slime when terminal is requested but target is missing", function()
+    state.config = config.normalize({
+      transport = {
+        backend = "terminal",
       },
     })
 
@@ -83,5 +129,98 @@ describe("core.transport.tmux_native queue", function()
     assert.is_true(first.ok)
     assert.is_false(second.ok)
     assert.are.equal("transport_queue_full", second.reason)
+  end)
+end)
+
+describe("core.transport.terminal", function()
+  local orig_chan_send
+  local term_bufnr
+  local term_jobid
+
+  local function create_terminal()
+    local prev_buf = vim.api.nvim_get_current_buf()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    local jobid = vim.fn.termopen({ "cat" })
+    vim.api.nvim_set_current_buf(prev_buf)
+    vim.wait(1000, function()
+      return tonumber(vim.fn.getbufvar(bufnr, "&channel")) == jobid
+    end, 10)
+    return bufnr, jobid
+  end
+
+  before_each(function()
+    orig_chan_send = vim.api.nvim_chan_send
+    vim.g.slimetree_terminal_config = nil
+    vim.g.slime_target = nil
+    vim.g.slime_default_config = nil
+    state.config = config.normalize({
+      transport = {
+        backend = "terminal",
+      },
+    })
+    state.reset_transport()
+  end)
+
+  after_each(function()
+    vim.api.nvim_chan_send = orig_chan_send
+    vim.g.slimetree_terminal_config = nil
+    vim.g.slime_target = nil
+    vim.g.slime_default_config = nil
+    if term_jobid then
+      pcall(vim.fn.jobstop, term_jobid)
+    end
+    if term_bufnr and vim.api.nvim_buf_is_valid(term_bufnr) then
+      pcall(vim.api.nvim_buf_delete, term_bufnr, { force = true })
+    end
+    term_bufnr = nil
+    term_jobid = nil
+    state.reset_transport()
+  end)
+
+  it("derives a terminal job from a configured terminal buffer", function()
+    term_bufnr, term_jobid = create_terminal()
+    vim.g.slimetree_terminal_config = {
+      bufnr = term_bufnr,
+    }
+
+    local target = terminal.resolve_target(0)
+
+    assert.are.same({
+      bufnr = term_bufnr,
+      jobid = term_jobid,
+    }, target)
+  end)
+
+  it("sends bracketed paste payloads to the configured terminal job", function()
+    term_bufnr, term_jobid = create_terminal()
+    vim.g.slimetree_terminal_config = {
+      jobid = term_jobid,
+    }
+    state.config = config.normalize({
+      transport = {
+        backend = "terminal",
+        terminal = {
+          bracketed_paste = true,
+        },
+      },
+    })
+
+    local sent = {}
+    vim.api.nvim_chan_send = function(jobid, payload)
+      sent.jobid = jobid
+      sent.payload = payload
+    end
+
+    local result = terminal.send("x <- 1", {
+      bufnr = 0,
+      transport_cfg = state.config.transport,
+    })
+
+    assert.is_true(result.ok)
+    assert.are.equal("terminal", result.backend)
+    assert.are.equal(term_jobid, sent.jobid)
+    assert.are.equal("\27[200~x <- 1\27[201~\n", sent.payload)
+    assert.are.equal(1, state.transport.stats.sent)
   end)
 end)


### PR DESCRIPTION
## Summary

Adds a native Neovim terminal transport backend for slimetree send workflows.

## Details

The plugin already supported tmux-native and vim-slime transport paths, but users with a managed Neovim terminal target needed to fall back through slime-style configuration. This change adds first-class terminal backend configuration, backend resolution, payload formatting, and tests for terminal buffer/job targets.

The update also documents the new transport behavior and records the implementation spec so future changes can preserve the no-tmux default and the independent gootabs boundary.

## Verification

Ran the project Plenary spec suite:

```bash
nvim --headless -i NONE -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/spec { minimal_init = 'tests/minimal_init.lua' }" -c qa
```

All specs passed.
